### PR TITLE
Converted JSON objects need to be encoded, as expected by the Factory…

### DIFF
--- a/Linnworks/src/netcore/LinnworksAPI/JsonFormatter.cs
+++ b/Linnworks/src/netcore/LinnworksAPI/JsonFormatter.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
+using System.Net;
 
 namespace LinnworksAPI
 {
@@ -14,7 +15,7 @@ namespace LinnworksAPI
 
         public static string ConvertToJson<T>(T t)
         {
-            return JsonConvert.SerializeObject(t, SerializerSettingsDateFormat);
+            return WebUtility.UrlEncode(JsonConvert.SerializeObject(t, SerializerSettingsDateFormat));
         }
     }
 }


### PR DESCRIPTION
Requests to the Linnworks API would sometimes fail based on the characters that were in the object (", &, ', etc).  Turns out the object does not get encoded as the Web Request is expecting.  This resolves that.